### PR TITLE
Updates for Rider 2020.3.2

### DIFF
--- a/src/CleanCode/CleanCode.Rider.csproj
+++ b/src/CleanCode/CleanCode.Rider.csproj
@@ -14,7 +14,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="JetBrains.RdFramework" Version="2020.2.1">
+        <PackageReference Include="JetBrains.RdFramework" Version="2020.3.2">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0" PrivateAssets="All" />

--- a/src/CleanCode/CleanCode.csproj
+++ b/src/CleanCode/CleanCode.csproj
@@ -13,7 +13,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="JetBrains.RdFramework" Version="2020.2.1">
+        <PackageReference Include="JetBrains.RdFramework" Version="2020.3.2">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0" PrivateAssets="All" />

--- a/src/CleanCode/Features/ChainedReferences/ChainedReferencesCheckCs.cs
+++ b/src/CleanCode/Features/ChainedReferences/ChainedReferencesCheckCs.cs
@@ -1,8 +1,6 @@
 using System.Collections.Generic;
-using CleanCode.Resources;
 using CleanCode.Settings;
 using JetBrains.Application.Settings;
-using JetBrains.ReSharper.Daemon.Stages.Dispatcher;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp.Tree;

--- a/src/CleanCode/Features/ChainedReferences/ChainedReferencesCheckVb.cs
+++ b/src/CleanCode/Features/ChainedReferences/ChainedReferencesCheckVb.cs
@@ -1,8 +1,6 @@
 using System.Collections.Generic;
-using CleanCode.Resources;
 using CleanCode.Settings;
 using JetBrains.Application.Settings;
-using JetBrains.ReSharper.Daemon.Stages.Dispatcher;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Tree;

--- a/src/CleanCode/Features/ClassTooBig/ClassTooBigCheckCs.cs
+++ b/src/CleanCode/Features/ClassTooBig/ClassTooBigCheckCs.cs
@@ -1,6 +1,5 @@
 using CleanCode.Settings;
 using JetBrains.Application.Settings;
-using JetBrains.ReSharper.Daemon.Stages.Dispatcher;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Tree;

--- a/src/CleanCode/Features/ClassTooBig/ClassTooBigCheckVb.cs
+++ b/src/CleanCode/Features/ClassTooBig/ClassTooBigCheckVb.cs
@@ -1,6 +1,5 @@
 using CleanCode.Settings;
 using JetBrains.Application.Settings;
-using JetBrains.ReSharper.Daemon.Stages.Dispatcher;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.ReSharper.Psi.VB.Tree;

--- a/src/CleanCode/Features/ComplexExpression/ComplexConditionExpressionCheckCs.cs
+++ b/src/CleanCode/Features/ComplexExpression/ComplexConditionExpressionCheckCs.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using CleanCode.Settings;
 using JetBrains.Application.Settings;
-using JetBrains.ReSharper.Daemon.Stages.Dispatcher;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Tree;

--- a/src/CleanCode/Features/ExcessiveIndentation/ExcessiveIndentationCheckCs.cs
+++ b/src/CleanCode/Features/ExcessiveIndentation/ExcessiveIndentationCheckCs.cs
@@ -1,6 +1,5 @@
 using CleanCode.Settings;
 using JetBrains.Application.Settings;
-using JetBrains.ReSharper.Daemon.Stages.Dispatcher;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Tree;

--- a/src/CleanCode/Features/FlagArguments/FlagArgumentsCheckCs.cs
+++ b/src/CleanCode/Features/FlagArguments/FlagArgumentsCheckCs.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.ReSharper.Daemon.Stages.Dispatcher;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp.Tree;

--- a/src/CleanCode/Features/HollowNames/HollowNamesCheckCs.cs
+++ b/src/CleanCode/Features/HollowNames/HollowNamesCheckCs.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using CleanCode.Resources;
 using CleanCode.Settings;
 using JetBrains.Application.Settings;
-using JetBrains.ReSharper.Daemon.Stages.Dispatcher;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Tree;

--- a/src/CleanCode/Features/HollowNames/HollowNamesCheckVb.cs
+++ b/src/CleanCode/Features/HollowNames/HollowNamesCheckVb.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using CleanCode.Resources;
 using CleanCode.Settings;
 using JetBrains.Application.Settings;
-using JetBrains.ReSharper.Daemon.Stages.Dispatcher;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.VB.Tree;
 using JetBrains.ReSharper.Psi.Tree;

--- a/src/CleanCode/Features/MethodNameNotMeaningful/MethodNameNotMeaningfulCheckCs.cs
+++ b/src/CleanCode/Features/MethodNameNotMeaningful/MethodNameNotMeaningfulCheckCs.cs
@@ -1,6 +1,5 @@
 using CleanCode.Settings;
 using JetBrains.Application.Settings;
-using JetBrains.ReSharper.Daemon.Stages.Dispatcher;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Tree;

--- a/src/CleanCode/Features/MethodNameNotMeaningful/MethodNameNotMeaningfulCheckVb.cs
+++ b/src/CleanCode/Features/MethodNameNotMeaningful/MethodNameNotMeaningfulCheckVb.cs
@@ -1,6 +1,5 @@
 using CleanCode.Settings;
 using JetBrains.Application.Settings;
-using JetBrains.ReSharper.Daemon.Stages.Dispatcher;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.VB.Tree;
 using JetBrains.ReSharper.Psi.Tree;

--- a/src/CleanCode/Features/MethodTooLong/MethodTooLongCheckCs.cs
+++ b/src/CleanCode/Features/MethodTooLong/MethodTooLongCheckCs.cs
@@ -1,6 +1,5 @@
 using CleanCode.Settings;
 using JetBrains.Application.Settings;
-using JetBrains.ReSharper.Daemon.Stages.Dispatcher;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Tree;

--- a/src/CleanCode/Features/MethodTooLong/MethodTooLongCheckVb.cs
+++ b/src/CleanCode/Features/MethodTooLong/MethodTooLongCheckVb.cs
@@ -1,6 +1,5 @@
 using CleanCode.Settings;
 using JetBrains.Application.Settings;
-using JetBrains.ReSharper.Daemon.Stages.Dispatcher;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.ReSharper.Psi.VB.Tree;

--- a/src/CleanCode/Features/TooManyDependencies/TooManyDependenciesCheckCs.cs
+++ b/src/CleanCode/Features/TooManyDependencies/TooManyDependenciesCheckCs.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using CleanCode.Settings;
 using JetBrains.Application.Settings;
-using JetBrains.ReSharper.Daemon.Stages.Dispatcher;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Tree;

--- a/src/CleanCode/Features/TooManyDependencies/TooManyDependenciesCheckVb.cs
+++ b/src/CleanCode/Features/TooManyDependencies/TooManyDependenciesCheckVb.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using CleanCode.Settings;
 using JetBrains.Application.Settings;
-using JetBrains.ReSharper.Daemon.Stages.Dispatcher;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.ReSharper.Psi.Util;

--- a/src/CleanCode/Features/TooManyMethodArguments/TooManyMethodArgumentsCheckCs.cs
+++ b/src/CleanCode/Features/TooManyMethodArguments/TooManyMethodArgumentsCheckCs.cs
@@ -1,6 +1,5 @@
 using CleanCode.Settings;
 using JetBrains.Application.Settings;
-using JetBrains.ReSharper.Daemon.Stages.Dispatcher;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.ReSharper.Psi.Tree;

--- a/src/CleanCode/Features/TooManyMethodArguments/TooManyMethodArgumentsCheckVb.cs
+++ b/src/CleanCode/Features/TooManyMethodArguments/TooManyMethodArgumentsCheckVb.cs
@@ -1,6 +1,5 @@
 using CleanCode.Settings;
 using JetBrains.Application.Settings;
-using JetBrains.ReSharper.Daemon.Stages.Dispatcher;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.ReSharper.Psi.VB.Tree;

--- a/src/Plugin.props
+++ b/src/Plugin.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <SdkVersion>2020.2.1</SdkVersion>
+    <SdkVersion>2020.3.2</SdkVersion>
     <Title>CleanCode</Title>
     <Description>Automates some of the concepts in Uncle Bob's Clean Code book</Description>
     <Authors>Martin Oehlert, Hadi Hariri, Matt Ellis</Authors>


### PR DESCRIPTION
This fixes the required dependencies for Rider 2020.3.2.

This supersedes the PRs #41 and #46.