### PR TITLE
fix: use setup-dotnet built-in NuGet cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,8 +30,21 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
 
+      - name: Cache IntelliJ Platform
+        uses: actions/cache@v4
+        with:
+          path: ~/.intellijPlatform
+          key: intellij-${{ hashFiles('gradle.properties') }}
+
       - name: Build Plugin
-        run: ./gradlew buildPlugin --build-cache
+        if: github.ref != 'refs/heads/master'
+        run: ./gradlew buildPlugin --parallel --build-cache
+
+      - name: Build & Publish Plugin
+        if: github.ref == 'refs/heads/master'
+        run: ./gradlew publishPlugin -PBuildConfiguration="Release" -PPublishToken="$PUBLISH_KEY" --parallel --build-cache
+        env:
+          PUBLISH_KEY: ${{ secrets.PublishKey }}
 
       - name: Publish Artifact
         uses: actions/upload-artifact@v4
@@ -39,9 +52,3 @@ jobs:
           name: Artifacts
           path: output
           retention-days: 7
-
-      - name: Publish plugins to jetbrains
-        run: ./gradlew publishPlugin -PBuildConfiguration="Release" -PPublishToken="$PUBLISH_KEY" --build-cache
-        env:
-          PUBLISH_KEY: ${{ secrets.PublishKey }}
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,17 +24,11 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.x'
+          cache: true
+          cache-dependency-path: src/dotnet/*/*.csproj
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
-
-      - name: Cache NuGet packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('src/dotnet/*/*.csproj', 'src/dotnet/*.props') }}
-          restore-keys: |
-            ${{ runner.os }}-nuget-
 
       - name: Build Plugin
         run: ./gradlew buildPlugin --build-cache


### PR DESCRIPTION
## Summary
- Replaced manual `actions/cache` step with `setup-dotnet`'s built-in `cache: true` option
- The previous `~/.nuget/packages` path didn't resolve correctly on Windows runners, so the NuGet cache was never restored
- `setup-dotnet` handles the platform-specific NuGet packages path automatically

## Test plan
- [ ] Verify CI build succeeds
- [ ] Check for "Cache restored" in the setup-dotnet step output