### PR TITLE
fix: use correct path for IntelliJ Platform cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Cache IntelliJ Platform
         uses: actions/cache@v4
         with:
-          path: ~/.intellijPlatform
+          path: .intellijPlatform
           key: intellij-${{ hashFiles('gradle.properties') }}
 
       - name: Build Plugin


### PR DESCRIPTION
## Summary
- The IntelliJ Platform cache was never hit because the workflow cached `~/.intellijPlatform` while the Gradle plugin stores artifacts in the project-local `.intellijPlatform/` directory.
- Fixes the path from `~/.intellijPlatform` to `.intellijPlatform`.

## Test plan
- [x] Verify the CI build populates the cache on the first run
- [x] Verify subsequent runs show a cache hit for the `Cache IntelliJ Platform` step